### PR TITLE
Allow use of different AWS regions using an atttribute

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -1,3 +1,3 @@
-site :opscode
+source "https://supermarket.chef.io"
 
 metadata

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Populate the sendmail attribute and include the default recipe `recipe[sendmail-
   * `port` tcp port. Default is 25
   * `test_user` SES verified user to send from.  IE <test_user>@<domain>
   * `test_email` Send a test email to the given address.
-
+  * `aws_region` the AWS region to use - default is us-east-1
 # Recipes
 
 default - Handles all integration

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # sendmail-ses cookbook
 
-Integrates sendmail with Amazon SES.  This cookbooks duplicates this [doc](http://docs.aws.amazon.com/ses/latest/DeveloperGuide/sendmail.html) except rather than adding the configurations directly to the sendmail.mc file.  It is included as a seperate file.
+Integrates sendmail with Amazon SES.  This cookbooks duplicates this [doc](http://docs.aws.amazon.com/ses/latest/DeveloperGuide/sendmail.html) except rather than adding the configurations directly to the sendmail.mc file.  It is included as a separate file.
 
 # Requirements
 
@@ -21,6 +21,7 @@ Populate the sendmail attribute and include the default recipe `recipe[sendmail-
   * `test_user` SES verified user to send from.  IE <test_user>@<domain>
   * `test_email` Send a test email to the given address.
   * `aws_region` the AWS region to use - default is us-east-1
+
 # Recipes
 
 default - Handles all integration

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,0 +1,2 @@
+default['sendmail_ses']['port']=25
+default['sendmail_ses']['aws_region']='us-east-1'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -27,7 +27,8 @@ if node.attribute? 'sendmail_ses'
     source 'authinfo.ses.erb'
     variables(
       :username => node[:sendmail_ses][:username],
-      :password => node[:sendmail_ses][:password]
+      :password => node[:sendmail_ses][:password],
+      :aws_region => node[:sendmail_ses][:aws_region]
     )
     notifies :run, 'execute[add_ses_authinfo]', :immediately
   end
@@ -37,11 +38,11 @@ if node.attribute? 'sendmail_ses'
     action :nothing
   end
 
-  file '/etc/mail/access.ses' do
-    content <<-CMD
-Connect:email-smtp.us-east-1.amazonaws.com RELAY
-Connect:ses-smtp-prod-335357831.us-east-1.elb.amazonaws.com RELAY
-CMD
+  template '/etc/mail/access.ses' do
+    source 'access.ses.erb'
+    variables(
+      :aws_region => node[:sendmail_ses][:aws_region]
+    )
     notifies :run, 'execute[add_ses_access]', :immediately
   end
 
@@ -69,7 +70,8 @@ CMD
     source 'ses.cf.erb'
     variables(
       :port => node[:sendmail_ses][:port] || '25',
-      :domain => node[:sendmail_ses][:domain]
+      :domain => node[:sendmail_ses][:domain],
+      :aws_region => node[:sendmail_ses][:aws_region]
     )
     notifies :run, 'ruby_block[add_include_to_sendmail_mc]'
   end

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -41,7 +41,7 @@ describe 'sendmail-ses::default' do
     end
 
     it 'create access.ses with content' do
-      expect(@chef_run).to create_file('/etc/mail/access.ses')
+      expect(@chef_run).to create_template('/etc/mail/access.ses')
       expect(@chef_run).to render_file('/etc/mail/access.ses').with_content(<<-CMD
 Connect:email-smtp.us-east-1.amazonaws.com RELAY
 Connect:ses-smtp-prod-335357831.us-east-1.elb.amazonaws.com RELAY
@@ -50,8 +50,8 @@ CMD
     end
 
     it 'template access.ses should notify add_ses_access' do
-      f = @chef_run.file('/etc/mail/access.ses')
-      expect(f).to notify('execute[add_ses_access]')
+      t = @chef_run.template('/etc/mail/access.ses')
+      expect(t).to notify('execute[add_ses_access]')
     end
 
     it 'should create ses directory' do

--- a/templates/default/access.ses.erb
+++ b/templates/default/access.ses.erb
@@ -1,0 +1,2 @@
+Connect:email-smtp.<%= @aws_region %>.amazonaws.com RELAY
+Connect:ses-smtp-prod-335357831.<%= @aws_region %>.elb.amazonaws.com RELAY

--- a/templates/default/authinfo.ses.erb
+++ b/templates/default/authinfo.ses.erb
@@ -1,2 +1,2 @@
-AuthInfo:email-smtp.us-east-1.amazonaws.com "U:root" "I:<%= @username %>" "P:<%= @password %>" "M:LOGIN"
-AuthInfo:ses-smtp-prod-335357831.us-east-1.elb.amazonaws.com "U:root" "I:<%= @username %>" "P:<%= @password %>" "M:LOGIN"
+AuthInfo:email-smtp.<%= @aws_region %>.amazonaws.com "U:root" "I:<%= @username %>" "P:<%= @password %>" "M:LOGIN"
+AuthInfo:ses-smtp-prod-335357831.<%= @aws_region %>.elb.amazonaws.com "U:root" "I:<%= @username %>" "P:<%= @password %>" "M:LOGIN"

--- a/templates/default/ses.cf.erb
+++ b/templates/default/ses.cf.erb
@@ -1,7 +1,7 @@
 dnl #
 dnl # Amazon SES integration
 dnl #
-define(`SMART_HOST', `email-smtp.us-east-1.amazonaws.com')dnl
+define(`SMART_HOST', `email-smtp.<%= @aws_region %>.amazonaws.com')dnl
 define(`RELAY_MAILER_ARGS', `TCP $h <%= @port %>')dnl
 define(`confAUTH_MECHANISMS', `LOGIN PLAIN')dnl
 FEATURE(`authinfo', `hash -o /etc/mail/authinfo.db')dnl


### PR DESCRIPTION
Attribute-ised the "us-east-1" part of all the config strings